### PR TITLE
Fix checksum, refactor checks

### DIFF
--- a/base58check-test.js
+++ b/base58check-test.js
@@ -26,8 +26,38 @@ async function toWif() {
     "XFPxuUn5Epz625e6FXAVXL5W8C87iLc8q8KK8ioexsU8dwj9RidW",
     "XFdqUukoCypRmmSrVWCZm5gFC7DGKNByHr66DmVL6JZTEPzmkoog",
     "XCBPnETeYM3CESgw94wM19u6qR4YWkokHB9MuCD4faTMbVeBRkmT",
-  ].reduce(async function (prev, prv) {
-    await b58c.verify(prv);
+  ].reduce(async function (prev, wif) {
+    await b58c.verify(wif);
+
+    let decoded = await b58c.decode(wif);
+    let check = await b58c.checksum({
+      privateKey: decoded.privateKey,
+    });
+
+    try {
+      await b58c.checksum({
+        pubKeyHash: decoded.privateKey,
+      });
+      throw new Error("allowed checksum of wrong key type");
+    } catch (e) {
+      // ignore, expected
+    }
+
+    if (decoded.check !== check) {
+      throw new Error("checksum({ privateKey }) failed");
+    }
+
+    let encoded = await b58c.encode({
+      version: undefined,
+      privateKey: decoded.privateKey,
+    });
+    let decoded2 = await b58c.decode(encoded);
+    if (decoded.privateKey !== decoded2.privateKey) {
+      throw new Error(`private keys don't match`);
+    }
+    if (decoded.privateKey !== decoded2.privateKey) {
+      throw new Error(`checksums don't match`);
+    }
   }, Promise.resolve());
 }
 
@@ -46,6 +76,22 @@ async function toPubKeyHash() {
 
   let parts = await b58c.verify(addr);
   console.info(`\t` + JSON.stringify(parts));
+
+  let check = await b58c.checksum({
+    pubKeyHash: parts.pubKeyHash,
+  });
+  if (parts.check !== check) {
+    throw new Error("checksum({ privateKey }) failed");
+  }
+
+  try {
+    await b58c.checksum({
+      privateKey: parts.pubKeyHash,
+    });
+    throw new Error("allowed checksum of pubKeyHash for privateKey");
+  } catch (e) {
+    // ignore, expected
+  }
 
   let full = await b58c.encode(parts);
   console.info(`\t${full}`);

--- a/base58check.js
+++ b/base58check.js
@@ -52,7 +52,7 @@
       if (parts.pubKeyHash) {
         if (parts.privateKey) {
           throw new Error(
-            `[@root/base58check] either 'privateKey' or 'pubKeyHash' must exist, but not both`
+            `[@dashincubator/base58check] either 'privateKey' or 'pubKeyHash' must exist, but not both`
           );
         }
       }
@@ -69,7 +69,7 @@
       if (parts.privateKey) {
         if (parts.version === pubKeyHashVersion) {
           throw new Error(
-            `[@root/base58check] '${parts.version}' is a public version, but the given key is private`
+            `[@dashincubator/base58check] '${parts.version}' is a public version, but the given key is private`
           );
         }
         return;
@@ -78,7 +78,7 @@
       if (parts.pubKeyHash) {
         if (parts.version === privateKeyVersion) {
           throw new Error(
-            `[@root/base58check] '${parts.version}' is a private version, but the given key is a pubKeyHash`
+            `[@dashincubator/base58check] '${parts.version}' is a private version, but the given key is a pubKeyHash`
           );
         }
       }
@@ -162,7 +162,7 @@
       }
 
       throw new Error(
-        `[@root/base58check] either 'privateKey' or 'pubKeyHash' must exist to encode`
+        `[@dashincubator/base58check] either 'privateKey' or 'pubKeyHash' must exist to encode`
       );
     };
 
@@ -181,7 +181,7 @@
           aCompressed = "an uncompressed";
         }
         throw new Error(
-          `[@root/base58check] ${key.length} is not a valid length for ${aCompressed} private key - it should be 33 (compressed) or 32 (uncompressed) bytes (66 or 64 hex chars)`
+          `[@dashincubator/base58check] ${key.length} is not a valid length for ${aCompressed} private key - it should be 33 (compressed) or 32 (uncompressed) bytes (66 or 64 hex chars)`
         );
       }
 
@@ -198,7 +198,7 @@
 
       if (40 !== key.length) {
         throw new Error(
-          `[@root/base58check] ${key.length} is not a valid pub key hash length, should be 20 bytes (40 hex chars)`
+          `[@dashincubator/base58check] ${key.length} is not a valid pub key hash length, should be 20 bytes (40 hex chars)`
         );
       }
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "base58check": "./bin/base58check.js"
   },
   "scripts": {
+    "fmt": "npx prettier@2 --write '*/**.{js,md}' ",
     "test": "node base58check-test.js",
     "version": "npm version -m \"chore(release): bump to v%s\""
   },


### PR DESCRIPTION
There was an issue where sometimes the correct `compression` and or `version` values were not being applied.

Now they are all applied consistently.

Tests have been updated too.